### PR TITLE
Specify version of Progress, use npm instead of github as source

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,5 @@
     "ramda": "^0.23.0",
     "string": "^3.3.3",
     "to-pascal-case": "^1.0.0"
-  },
-  "devDependencies": {
-    "@procore/js-sdk-endpoints": "^1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "commander": "^2.9.0",
     "handlebars": "^4.0.6",
     "isomorphic-fetch": "^2.2.1",
-    "progress": "https://github.com/visionmedia/node-progress",
+    "progress": "^2.0.0",
     "ramda": "^0.23.0",
     "string": "^3.3.3",
     "to-pascal-case": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk-endpoints",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "generates endpoint functions for node-procore sdk",
   "main": "endpoints/index.ts",
   "bin": {
@@ -19,6 +19,6 @@
     "to-pascal-case": "^1.0.0"
   },
   "devDependencies": {
-    "@procore/js-sdk-endpoints": "^1.8.1"
+    "@procore/js-sdk-endpoints": "^1.9.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@procore/js-sdk-endpoints@^1.8.1":
+"@procore/js-sdk-endpoints@^1.9.1":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.0.tgz#0d060ef2f89ad475e706c787595f085f1fc68913"
   dependencies:
@@ -167,9 +167,9 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-"progress@https://github.com/visionmedia/node-progress":
+"progress@git+https://github.com/visionmedia/node-progress.git":
   version "2.0.0"
-  resolved "https://github.com/visionmedia/node-progress#30d70d968c4a39b44282cc70c42a026cd8f86fcc"
+  resolved "git+https://github.com/visionmedia/node-progress.git#30d70d968c4a39b44282cc70c42a026cd8f86fcc"
 
 ramda@^0.23.0:
   version "0.23.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,6 @@
 # yarn lockfile v1
 
 
-"@procore/js-sdk-endpoints@^1.9.1":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.0.tgz#0d060ef2f89ad475e706c787595f085f1fc68913"
-  dependencies:
-    chalk "^1.1.3"
-    commander "^2.9.0"
-    handlebars "^4.0.6"
-    isomorphic-fetch "^2.2.1"
-    progress "https://github.com/visionmedia/node-progress"
-    ramda "^0.23.0"
-    string "^3.3.3"
-    to-pascal-case "^1.0.0"
-
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -38,10 +25,6 @@ ansi-styles@^2.2.1:
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
-async@~0.2.6:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
 camelcase@^1.0.2:
   version "1.2.1"
@@ -73,10 +56,8 @@ cliui@^2.1.0:
     wordwrap "0.0.2"
 
 commander@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
 decamelize@^1.0.0:
   version "1.2.0"
@@ -92,13 +73,9 @@ escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
 handlebars@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -113,12 +90,14 @@ has-ansi@^2.0.0:
     ansi-regex "^2.0.0"
 
 iconv-lite@~0.4.13:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
-is-buffer@^1.0.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
 is-stream@^1.0.1:
   version "1.1.0"
@@ -132,10 +111,10 @@ isomorphic-fetch@^2.2.1:
     whatwg-fetch ">=0.10.0"
 
 kind-of@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
-    is-buffer "^1.0.2"
+    is-buffer "^1.1.5"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -150,8 +129,8 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 node-fetch@^1.0.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -167,10 +146,6 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-"progress@git+https://github.com/visionmedia/node-progress.git":
-  version "2.0.0"
-  resolved "git+https://github.com/visionmedia/node-progress.git#30d70d968c4a39b44282cc70c42a026cd8f86fcc"
-
 ramda@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
@@ -185,6 +160,10 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -192,8 +171,8 @@ source-map@^0.4.4:
     amdefine ">=0.0.4"
 
 source-map@~0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 string@^3.3.3:
   version "3.3.3"
@@ -226,21 +205,21 @@ to-space-case@^1.0.0:
     to-no-case "^1.0.0"
 
 uglify-js@^2.6:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.5.tgz#ae9f5b143f4183d99a1dabb350e243fdc06641ed"
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
-    async "~0.2.6"
     source-map "~0.5.1"
-    uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
 whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 window-size@0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@procore/js-sdk-endpoints@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.7.2.tgz#2e12ab60e9feaea2aa5192c1f0a7b87f320bb05a"
+"@procore/js-sdk-endpoints@^1.8.1":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.0.tgz#0d060ef2f89ad475e706c787595f085f1fc68913"
   dependencies:
     chalk "^1.1.3"
     commander "^2.9.0"
@@ -163,13 +163,13 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-"progress@git+https://github.com/visionmedia/node-progress.git":
+progress@^2.0.0:
   version "2.0.0"
-  resolved "git+https://github.com/visionmedia/node-progress.git#d84326ed9ab7720592b6bbc9c108849cd2a79908"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 "progress@https://github.com/visionmedia/node-progress":
-  version "1.1.8"
-  resolved "https://github.com/visionmedia/node-progress#191256e02ec20c89b2e2834e25d17c3a7257d18a"
+  version "2.0.0"
+  resolved "https://github.com/visionmedia/node-progress#30d70d968c4a39b44282cc70c42a026cd8f86fcc"
 
 ramda@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
Looking at this circle build -> https://circleci.com/gh/procore/procore/245513#tests/containers/21

It seems that drawings is having a hard time `Fetching` this particular dependency (for the drawings tool, this is a sub dependency)

No hard evidence other than it is the one thing that is not like the other and figured since it is a positive change anyways, it is probably worth making.

Hopefully drawings stops failing on this particular task after it consumes this version of `js-sdk-endpoints`