### PR TITLE
Fix Camel Case Parentheses for TS Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Change Log
 
 ## 1.9.2
-- fix: URL generation handles parentheses and hyphens. Aligns with dev-portal doc viewer stub function
+- fix: URL param, camel case, and pascal case generation handles parentheses and hyphens. URL param stub aligns with dev-portal doc viewer stub function

--- a/endpoints.js
+++ b/endpoints.js
@@ -77,12 +77,22 @@ const removeNonProductionEndpoints = (endpoints) => new Promise(
   }
 );
 
+const REGEX_INVALID_SYMBOLS = /\.|\(|\)|'|"/g;
+
+function fromNameToCamelized(nameString) {
+  return S(nameString.toLowerCase().replace(REGEX_INVALID_SYMBOLS, '')).camelize().s;
+}
+
+function fromNameToPascal(nameString) {
+ return pascalCase(nameString.toLowerCase().replace(REGEX_INVALID_SYMBOLS, ''));
+}
+
 function fromNameToStub(nameString) {
   return nameString
     .toLowerCase()
     .trim()
     .replace(/ |\//g, '-')
-    .replace(/\.|\(|\)|'|"/g, '');
+    .replace(REGEX_INVALID_SYMBOLS, '');
 }
 
 const endpointCommand = (to, { destination, index }) => {
@@ -111,7 +121,6 @@ const endpointCommand = (to, { destination, index }) => {
 
       return Promise.all(
         groups.map(({ name }) => {
-          const endpointNameLowerCase = name.toLowerCase();
           const endpointNameStub = fromNameToStub(name);
           const endpointUrl = `${ENDOINTS_URL}/master/${endpointNameStub}.json`;
 
@@ -120,9 +129,8 @@ const endpointCommand = (to, { destination, index }) => {
             .then(removeNonProductionEndpoints)
             .then(([{ path: endpointPath, path_params, query_params }]) => {
               fs.readFile(endpointTemplatePath, 'utf8', (err, data) => {
-                const camelizedEndpointName = S(endpointNameLowerCase).camelize().s;
-
-                const pascalCaseEndpointName = pascalCase(endpointNameLowerCase);
+                const camelizedEndpointName = fromNameToCamelized(name);
+                const pascalCaseEndpointName = fromNameToPascal(name);
 
                 const params = R.when(
                   R.compose(
@@ -174,5 +182,7 @@ const endpointCommand = (to, { destination, index }) => {
     })
 }
 
+endpointCommand.fromNameToCamelized = fromNameToCamelized;
+endpointCommand.fromNameToPascal = fromNameToPascal;
 endpointCommand.fromNameToStub = fromNameToStub;
 module.exports= endpointCommand;

--- a/endpoints.js
+++ b/endpoints.js
@@ -84,7 +84,7 @@ function fromNameToCamelized(nameString) {
 }
 
 function fromNameToPascal(nameString) {
- return pascalCase(nameString.toLowerCase().replace(REGEX_INVALID_SYMBOLS, ''));
+ return pascalCase(nameString);
 }
 
 function fromNameToStub(nameString) {

--- a/endpoints.test.js
+++ b/endpoints.test.js
@@ -1,6 +1,44 @@
 const endpoints = require("./endpoints.js");
 
+const camel = endpoints.fromNameToCamelized;
+const pascal = endpoints.fromNameToPascal;
 const stub = endpoints.fromNameToStub;
+
+describe("fromNameToCamelized", () => {
+  it("single word example", () => {
+    expect(camel("EXAMPLE")).toEqual("example")
+  });
+  it("multi word example", () => {
+    expect(camel("Coordination Issue Recycle Bin")).toEqual("coordinationIssueRecycleBin");
+  });
+  it("remove underscores", () => {
+    expect(camel("Submittal_Logs")).toEqual("submittalLogs");
+  });
+  it("removes parentheses", () => {
+    expect(camel("Line Item Types (Cost Types)")).toEqual("lineItemTypesCostTypes");
+  });
+  it("removes hyphens", () => {
+    expect(camel("Managed Equipment - Company Level")).toEqual("managedEquipmentCompanyLevel");
+  });
+});
+
+describe("fromNameToPascal", () => {
+  it("single word example", () => {
+    expect(pascal("EXAMPLE")).toEqual("Example")
+  });
+  it("multi word example", () => {
+    expect(pascal("Coordination Issue Recycle Bin")).toEqual("CoordinationIssueRecycleBin");
+  });
+  it("remove underscores", () => {
+    expect(pascal("Submittal_Logs")).toEqual("SubmittalLogs");
+  });
+  it("removes parentheses", () => {
+    expect(pascal("Line Item Types (Cost Types)")).toEqual("LineItemTypesCostTypes");
+  });
+  it("removes hyphens", () => {
+    expect(pascal("Managed Equipment - Company Level")).toEqual("ManagedEquipmentCompanyLevel");
+  });
+});
 
 describe("fromNameToStub", () => {
   it("lowercases names", () => {
@@ -15,7 +53,7 @@ describe("fromNameToStub", () => {
   it("removes parentheses", () => {
     expect(stub("Line Item Types (Cost Types)")).toEqual("line-item-types-cost-types");
   });
-  it("handles hyphen seperator", () => {
+  it("keeps hyphen seperator", () => {
     expect(stub("Managed Equipment - Company Level")).toEqual("managed-equipment---company-level");
   });
 });


### PR DESCRIPTION
Related PR https://github.com/procore/js-sdk-endpoints/pull/10 (version change from PR has not been published)
Related Issue https://github.com/procore/js-sdk-endpoints/issues/9

- fix: handle parentheses symbols in camel case TS generation
- test: tests for camel case and pascal case generation

Before:
```ts
// index.ts
export { default as lineItemTypes(costTypes) } from './endpoints/line-item-types-cost-types'

// endpoints/line-item-types-cost-types.ts
function lineItemTypes(costTypes)({ action, qs, id }: LineItemTypesCostTypes): any {
  return {
    base: '/vapid/line_item_types',
    action,
    params: { id },
    qs
  }
}

export default lineItemTypes(costTypes)
```

After:
```ts
// index.ts
export { default as lineItemTypesCostTypes } from './endpoints/line-item-types-cost-types'

// endpoints/line-item-types-cost-types.ts
function lineItemTypesCostTypes({ action, qs, id }: LineItemTypesCostTypes): any {
  return {
    base: '/vapid/line_item_types',
    action,
    params: { id },
    qs
  }
}

export default lineItemTypesCostTypes
```